### PR TITLE
Fixes issue where messages are not built before they are used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ set(CUDA_USE_STATIC_CUDA_RUNTIME  OFF)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
+  gencpp
+  genpy
   std_msgs
   message_generation
   cv_bridge
@@ -150,7 +152,7 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(
-# include
+  include
   ${catkin_INCLUDE_DIRS}
 #  ${PCL_INCLUDE_DIRS}
 )


### PR DESCRIPTION
Fixes #7 better than just recompiling several times. Gencpp and genpy were not used as components