### PR TITLE
Exposure Time WIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 
 add_message_files(
   FILES
-  SpinnakerImageNames.msg
+  SpinnakerImageInfo.msg
 )
 
 generate_dynamic_reconfigure_options(

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ All the parameters can be set via the launch file or via the yaml config_file.  
   Exposure setting for cameras, also available as dynamic reconfiguarble parameter.
   * ~external_trigger (bool, default: false)  
   Camera triggering setting when using an external trigger.  In this mode, none of the cameras would be set as a master camera. All cameras are setup to use external trigger.  In this mode the main loop runs at rate set by soft_framerate, so if the external trigger rate is higher than the soft_framerate, the buffer will get filled and images will have a lag. Also in this mode, the getnextimage timeout is set to infinite so that the node dosen't die if a trigger is not received for a while.
+* ~publish_exposure_times (bool, default: false)
+  Turn on publishing of image exposure times to the "camera/exposure_times" topic, using the SpinnakerExposureTimes message type.
+* ~account_for_exposure_time (bool, default: false)
+  Change time stamps for published images to be at the center of their exposure window (starting time stamp + 1/2 exposure time).
 * ~target_grey_value (double, default: 0 , 0:Continous/auto)
   Setting target_grey_value > 4 (min:4 , max:99) will turn AutoExposureTargetGreyValueAuto to 'off' and set AutoExposureTargetGreyValue to target_grey_value. Also available as dynamic reconfigurable parameter. see below in Dynamic reconfigurable parameter section.
 * ~frames (int, default: 50)  

--- a/include/spinnaker_sdk_camera_driver/camera.h
+++ b/include/spinnaker_sdk_camera_driver/camera.h
@@ -28,8 +28,13 @@ namespace acquisition {
 
         ImagePtr grab_frame();
         Mat grab_mat_frame();
-        string get_time_stamp();
+        string get_time_stamp_str();
+        double get_exposure_time();
         int get_frame_id();
+
+        void enableTimestampCorrection();
+        void enableChunkData();
+        void enableChunkDataType(string);
 
         void setEnumValue(string, string);
         void setIntValue(string, int);
@@ -73,12 +78,14 @@ namespace acquisition {
         
         CameraPtr pCam_;
         int64_t timestamp_;
+        double exposure_time_;
         int frameID_;
         int lastFrameID_;
 
         bool COLOR_;
         bool MASTER_;
         uint64_t GET_NEXT_IMAGE_TIMEOUT_;
+        bool EXPOSURE_TIME_ADJUST_;
 
     };
 

--- a/include/spinnaker_sdk_camera_driver/capture.h
+++ b/include/spinnaker_sdk_camera_driver/capture.h
@@ -14,7 +14,7 @@
 #include <dynamic_reconfigure/server.h>
 #include <spinnaker_sdk_camera_driver/spinnaker_camConfig.h>
 
-#include "spinnaker_sdk_camera_driver/SpinnakerImageNames.h"
+#include "spinnaker_sdk_camera_driver/SpinnakerImageInfo.h"
 
 #include <sstream>
 #include <image_transport/image_transport.h>
@@ -70,7 +70,7 @@ namespace acquisition {
 
         float mem_usage();
     
-        SystemPtr system_;    
+        SystemPtr system_;
         CameraList camList_;
         vector<acquisition::Camera> cams;
         vector<string> cam_ids_;
@@ -80,7 +80,8 @@ namespace acquisition {
         vector<CameraPtr> pCams_;
         vector<ImagePtr> pResultImages_;
         vector<Mat> frames_;
-        vector<string> time_stamps_;
+        vector<string> time_stamp_strs_;
+        vector<double> exposure_times_;
         vector< vector<Mat> > mem_frames_;
         vector<vector<double>> intrinsic_coeff_vec_;
         vector<vector<double>> distortion_coeff_vec_;
@@ -132,6 +133,8 @@ namespace acquisition {
         bool PUBLISH_CAM_INFO_;
         bool VERIFY_BINNING_;
         uint64_t SPINNAKER_GET_NEXT_IMAGE_TIMEOUT_;
+        bool PUBLISH_EXPOSURE_TIMES_;
+        bool CORRECT_TIMESTAMPS_;
         
         bool region_of_interest_set_;
         int region_of_interest_width_;
@@ -158,8 +161,8 @@ namespace acquisition {
 		
         vector<sensor_msgs::ImagePtr> img_msgs;
         vector<sensor_msgs::CameraInfoPtr> cam_info_msgs;
-        spinnaker_sdk_camera_driver::SpinnakerImageNames mesg;
-        boost::mutex queue_mutex_;  
+        spinnaker_sdk_camera_driver::SpinnakerImageInfo mesg;
+        boost::mutex queue_mutex_;
     };
 
 }

--- a/msg/SpinnakerImageInfo.msg
+++ b/msg/SpinnakerImageInfo.msg
@@ -1,3 +1,4 @@
 Header      header
 string[]    name
 time        time
+duration[]  exposure_times


### PR DESCRIPTION
Adds the options to publish exposure times with every frame to ROS, as well as the ability to adjust image timestamps based on those exposure times.

Tested on my local machine, I am able to see exposure times change as auto-exposure is adjusted by the camera.

Let me know if you see anything else to change!