### PR TITLE
Fix ros::Rate issue

### DIFF
--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -1036,7 +1036,7 @@ void acquisition::Capture::run_soft_trig() {
     }
 
 
-    ros::Rate ros_rate(soft_framerate_);
+    ros::Rate ros_rate(SOFT_FRAME_RATE_CTRL_? soft_framerate_: 1.0);
     try{
         while( ros::ok() ) {
 


### PR DESCRIPTION
Fix an issue when the parameter soft_framerate is set to 0. In this case we would create an object ros::Rate ros_rate(0) which is not allowed and the node would crash. The fact that we create the object with argument 1.0 or any other argument won't matter when SOFT_FRAME_RATE_CTRL_ is set to false, which is the case when soft_framerate = 0, won't matter as we wouldn't enter the if condition if (SOFT_FRAME_RATE_CTRL_), so we won't sleep.